### PR TITLE
Add missing .url for the image on slides/index

### DIFF
--- a/app/views/spree/admin/slides/index.html.erb
+++ b/app/views/spree/admin/slides/index.html.erb
@@ -26,7 +26,7 @@
       <% @slides.each do |slide|%>
         <tr id='<%= spree_dom_id slide %>' data-hook='admin_slides_index_rows'>
           <td class='no-border'><span class='handle'></span></td>
-          <td class='align-left'><%= image_tag slide.slide_image, style: 'width: 120px; height: auto;' %></td>
+          <td class='align-left'><%= image_tag slide.slide_image.url, style: 'width: 120px; height: auto;' %></td>
           <td class='align-left'><%= link_to slide.name, object_url(slide) %></td>
           <td class='align-left'><%= link_to slide.product.name, object_url(slide) unless slide.product_id.blank? %></td>
           <td class='align-center'><%= slide.published ? Spree.t(:say_yes) : Spree.t(:say_no) %></td>


### PR DESCRIPTION
## Description
Add missing .url for the image on slides/index
- This was causing application crashing on newer versions of rails.