### PR TITLE
Fixing issue when editing a slide

### DIFF
--- a/app/views/spree/admin/slides/_form.html.erb
+++ b/app/views/spree/admin/slides/_form.html.erb
@@ -61,7 +61,7 @@
     <div class='col-2'>
       <%= f.field_container :image do %>
         <% if f.object.image? %>
-          <p><%= image_tag f.object.image, style: 'max-width: 100%; height: auto;' %></p>
+          <p><%= image_tag f.object.image.url, style: 'max-width: 100%; height: auto;' %></p>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
image_tag is now more strict and needs explicitly the image url